### PR TITLE
FE-858 Insert CSS scope classname to element HTML with package short …

### DIFF
--- a/recipes/internal-recipe/package.json
+++ b/recipes/internal-recipe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dr/internal-recipe",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Component group: internal-recipe",
   "dependencies": {
     "@dr-core/labjs": "0.1.0",
@@ -11,7 +11,7 @@
     "@dr-core/bundle-loader": "0.0.6",
     "@dr/parcelify-module-resolver": "0.0.35",
     "@dr/template-builder": "0.2.1",
-    "@dr-core/webpack2-builder": "0.1.4",
+    "@dr-core/webpack2-builder": "0.1.5",
     "@dr-core/express-app": "0.2.20",
     "@dr/http-server": "0.1.1",
     "@dr/logger": "0.0.28",

--- a/src/internal/compile/webpack2-builder/README.md
+++ b/src/internal/compile/webpack2-builder/README.md
@@ -23,6 +23,11 @@ Also it inlines `manifest` chunk in entry HTML file.
 
 ### api-loader
 Resolves `require('__api')` and `__api` expression statement, also works with **require-injector**.
+#### CSS scope
+If the JS file is a "main" file of a component package, it will be inserted with code:
+```js
+document.getElementsByTagName('html')[0].className += ' <package short name>';
+```
 
 ### @dr-core/webpack2-builder/lib/html-loader
 Replaces `assets://<component>/...` in *[src|href] from all html files.

--- a/src/internal/compile/webpack2-builder/lib/api-loader.js
+++ b/src/internal/compile/webpack2-builder/lib/api-loader.js
@@ -32,7 +32,14 @@ function loadAsync(content, loader) {
 
 function parse(source, loader) {
 	var file = loader.resourcePath;
+	var currPackage = api.findPackageByFile(file);
 	var hasApi = false;
+	if (currPackage && currPackage.longName !== api.packageName /*@dr-core/webpack2-builder*/ && file === currPackage.file) {
+		hasApi = true;
+		log.debug('Insert CSS scope classname to:\n %s', file);
+		source = `document.getElementsByTagName(\'html\')[0].className += \' ${currPackage.parsedName.name}\';
+${source}`;
+	}
 	var astFromCache = false;
 	//log.info('js file: %s, %s', file, _.get(currPackage, 'file'));
 
@@ -60,7 +67,7 @@ function parse(source, loader) {
 		delete loader.query.astFromCache[file];
 	//source = loader.query.injector.injectToFile(file, source, ast);
 	//loader.query.injector.removeListener('replace', loader.data.onReplaceApiCall);
-	var currPackage = api.findPackageByFile(file);
+
 	if (hasApi) {
 		source = apiTmpl({
 			packageName: currPackage.longName,

--- a/src/internal/compile/webpack2-builder/package.json
+++ b/src/internal/compile/webpack2-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dr-core/webpack2-builder",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Browser side stuff builder module based on Webpack2",
   "main": "main.js",
   "browser": "browser-api.js",

--- a/src/internal/compile/webpack2-builder/webpack.config.js
+++ b/src/internal/compile/webpack2-builder/webpack.config.js
@@ -214,7 +214,6 @@ module.exports = function(webpackConfigEntry, noParse, file2EntryChunkName, entr
 			if (_.has(file2EntryChunkName, file))
 				return true;
 			var component = api.findPackageByFile(file);
-
 			var isOurs = !!(component && (_.includes(componentScopes, component.parsedName.scope) ||
 				component.dr));
 			// if (!isOurs)


### PR DESCRIPTION
Your CSS/LESS file should always be wrapped in a scope (class name selector) with short name of package.

main.less
```less
.your-component {
   @import "some-other.less";
}
```

This change includes making @dr-core/webpack2-builder/lib/api-loader insert JS code to add class name to element "HTML" to each browser-side component main JS file.

